### PR TITLE
fix(data): change Bolt Nexus Target damage to 4

### DIFF
--- a/weapons.json
+++ b/weapons.json
@@ -144,7 +144,7 @@
       "on_hit": "",
       "damage": [{
         "type": "Energy",
-        "val": 1
+        "val": 4
       }],
       "range": [{
         "type": "Range",


### PR DESCRIPTION
# Description
This PR sets the Bolt Nexus's "Target Acquired" Profile damage to 4 to match the PDF.

## Issue Number
Closes #7

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)