### PR TITLE
decap'd 'variant' and 'license' fields

### DIFF
--- a/lib/frames.json
+++ b/lib/frames.json
@@ -164,7 +164,7 @@
   {
     "id": "mf_black_witch_alt_orchidea",
     "source": "SSC",
-    "variant": "BLACK WITCH",
+    "variant": "Black Witch",
     "name": "Orchis",
     "mechtype": ["Controller", "Defender"],
     "y_pos": 25,
@@ -239,7 +239,7 @@
   {
     "id": "mf_minotaur_alt_wraith",
     "source": "HORUS",
-    "variant": "MINOTAUR",
+    "variant": "Minotaur",
     "name": "Calendula",
     "mechtype": ["Controller"],
     "y_pos": 25,

--- a/lib/systems.json
+++ b/lib/systems.json
@@ -5,7 +5,7 @@
     "type": "System",
     "sp": 1,
     "source": "SSC",
-    "license": "WHITE WITCH",
+    "license": "White Witch",
     "license_level": 1,
     "actions": [
       {
@@ -36,7 +36,7 @@
       }
     ],
     "source": "SSC",
-    "license": "WHITE WITCH",
+    "license": "White Witch",
     "license_level": 2,
     "actions": [
       {
@@ -63,7 +63,7 @@
       }
     ],
     "source": "SSC",
-    "license": "WHITE WITCH",
+    "license": "White Witch",
     "license_level": 2,
     "actions": [
       {
@@ -91,7 +91,7 @@
     "type": "Deployable",
     "sp": 3,
     "source": "SSC",
-    "license": "WHITE WITCH",
+    "license": "White Witch",
     "license_level": 3,
     "deployables": [
       {
@@ -130,7 +130,7 @@
       }
     ],
     "source": "SSC",
-    "license": "EMPEROR",
+    "license": "Emperor",
     "license_level": 1,
     "actions": [
       {
@@ -154,7 +154,7 @@
       }
     ],
     "source": "SSC",
-    "license": "EMPEROR",
+    "license": "Emperor",
     "license_level": 2,
     "actions": [
       {
@@ -188,7 +188,7 @@
       }
     ],
     "source": "SSC",
-    "license": "EMPEROR",
+    "license": "Emperor",
     "license_level": 2,
     "actions": [
       {
@@ -212,7 +212,7 @@
       }
     ],
     "source": "SSC",
-    "license": "EMPEROR",
+    "license": "Emperor",
     "license_level": 3,
     "actions": [{
       "activation": "Quick",
@@ -244,7 +244,7 @@
       }
     ],
     "source": "SSC",
-    "license": "EMPEROR",
+    "license": "Emperor",
     "license_level": 3,
     "actions": [
       {

--- a/lib/weapons.json
+++ b/lib/weapons.json
@@ -23,7 +23,7 @@
       }
     ],
     "source": "SSC",
-    "license": "WHITE WITCH",
+    "license": "White Witch",
     "license_level": 1,
     "on_hit": "1/round, you may force a character hit by this weapon to make a Hull save. On a failure, both you and your target are Immobilized and cannot be moved in any way. For the duration, the target always considers you within range for melee attacks. On any subsequent turn, you can end this effect as a protocol, knocking your target 4 spaces in any direction, or your target can end it by successfully hitting you with a ranged or melee attack. This condition can’t be removed any other way.",
     "actions": [
@@ -141,7 +141,7 @@
       }
     ],
     "source": "SSC",
-    "license": "WHITE WITCH",
+    "license": "White Witch",
     "license_level": 3,
     "effect": "Any time you take damage from a hostile source you may choose to store a charge in this weapon. It fires with an additional +1d6 kinetic damage, Reliable 2, and Knockback 1 for each charge stored, to a maximum of 3 charges. Once fired, it clears all charges, hit or miss.",
     "description": "“Ultimately, I have to return to the core of what we made, the code we cracked when we finally figured out NO/EM. From a simple prompt, we created a terrible engine. I am more proud of what we did than anything I’ve ever worked on before, but it should never see the light of day. Working with Visual convinced me of this: it’s their job to translate our work to sales, and they could not. If the translator cannot understand the text … then who are they to rewrite it? Who is the reader to attempt to access it? I conclude my summary with this: mothball the platform. There are less terrible paths we can walk.”",
@@ -211,7 +211,7 @@
       }
     ],
     "source": "SSC",
-    "license": "EMPEROR",
+    "license": "Emperor",
     "license_level": 1,
     "description": "“But they denied Him. So their Lord brought down upon them destruction for their sin, and did not fear retribution, for He was the LORD, and above reproach. Put out your eye if you think otherwise.”<br>— Witnessed from the Cyrus 2.14 ferromemetic",
     "data_type": "weapon",


### PR DESCRIPTION
Minor decapitalizations to match the change in Frame names. Probably shouldn't affect much with `license_id` being the new standard but might be good for consistency's sake.