### PR TITLE
fix(data): word order typo in Little Consequence

### DIFF
--- a/lib/bonds.json
+++ b/lib/bonds.json
@@ -698,7 +698,7 @@
       {
         "name": "Little Consequence",
         "frequency": "1/session",
-        "description": "When you would take blame, personal fallout, or physical harm as a result of your actions, you have may another willing character nearby take the consequences instead of you after you learn what they are. If they do, they take 1 XP."
+        "description": "When you would take blame, personal fallout, or physical harm as a result of your actions, you may have another willing character nearby take the consequences instead of you after you learn what they are. If they do, they take 1 XP."
       },
       {
         "name": "The Ledger",


### PR DESCRIPTION
Minor word order typo in the Little Consequence bond power.

Closes #23