### PR TITLE
fix(systems): remove redundant quick_tech tag on Dom's Breadth

### DIFF
--- a/lib/systems.json
+++ b/lib/systems.json
@@ -117,9 +117,6 @@
     "sp": 2,
     "tags": [
       {
-        "id": "tg_quick_tech"
-      },
-      {
         "id": "tg_overshield"
       },
       {


### PR DESCRIPTION
# Description

Remove redundant Quick Tech tag from Dominion's Breadth.

## Issues Closed

Closes #28